### PR TITLE
Instance::dimension initialization

### DIFF
--- a/src/Instance.cpp
+++ b/src/Instance.cpp
@@ -1,6 +1,6 @@
 #include "Instance.h"
 
-Instance::Instance(const char* instanciaPath) {
+Instance::Instance(const char* instanciaPath) : dimension(0) {
     FILE* file = fopen(instanciaPath, "r");
 
     if(!file) {


### PR DESCRIPTION
Hi!
I might have found a little bug in the controller code. 
The "_dimension_" field of class "_Instance_" was not initialized to 0.

**Effect** 
The instance size is computed adding one for every node that is read from the instance input file.
When the uninitialized value inside "_dimension_" is non-zero, the controller discards all feasible solutions, since it require that non-existing customers are visited.

**Fix**
Initialize "_dimension_" to 0.

Regards,
Francesco
